### PR TITLE
Subsections 12.11 and 12.12; suggesting  environment 'wandwexample*'

### DIFF
--- a/src/tex/wandw-ch12.tex
+++ b/src/tex/wandw-ch12.tex
@@ -216,50 +216,32 @@ it is valid except when $z = 0, -1, -2, \ldots$.
 \Subsection{12}{1}{2}{The difference equation satisfied by the
   Gamma-function.} 
 
-\index{Difiference equation satisfied by the Gamma-function}
-We shall now shew that the function F (z) satisfies the difference
+\index{Difiference equation satisfied by the Gamma-function} We shall
+now shew that the function $\Gamma(z)$ satisfies the difference
 equation
-
-T z -l) = zT z). For, by Euler's formula, if z is not a negative
-integer,
-
-FU + 1)/F(.) = -
-
-lim n
-
-;h -* X = 1
-
-(1 +
-
-V n
-
-ly+r
-
-1 +
-
-z+ 1
-
-1 lim n ii
-
-m-*---c ? =1
-
-1 +
-
-1 J
-
-= - lim II,
-
-  + 1, -*x = 1 I + ?i +
-
-, . m + 1
-
-= z hm = z.
-
- i x 2: + Wi + 1
-
+\begin{displaymath}
+  \Gamma(z + 1) = z \Gamma(z) .
+\end{displaymath}
+For, by Euler's formula, if $z$ is not a negative integer,
+\begin{align*}
+\Gamma(z + 1)/\Gamma(z) 
+  &= 
+    \frac{1}{z+1} \thebracket{\lim_{m \rightarrow \infty}
+    \prod_{n=1}^{m} \frac{\theparen{1 + \frac{1}{n}}^{z+1}}{
+    1 + \frac{z+1}{n}} }
+    \div
+    \thebracket{ \frac{1}{z} \lim_{m \rightarrow \infty}
+    \prod_{n=1}^{m} \frac{\theparen{1 + \frac{1}{n}}^{z}}{
+    1 + \frac{z}{n}} } \\
+  &= 
+    \frac{z}{z+1} \lim_{m \rightarrow \infty} \prod_{n=1}^{m} 
+    \thebrace{\frac{\theparen{1 + \frac{1}{n}}(z+n)}{z + n + 1}} \\
+  &= 
+    z \lim_{m \rightarrow \infty} \frac{m+1}{z + m + 1} = z .
+\end{align*}
 This is one of the most important properties of the Gamma-function.
-Since F (1) = 1, it follows that, if 2: is a positive integer, F (2 )
-= (2 - 1) !.
+Since $\Gamma(1) = 1$, it follows that, if $z$ is a positive integer, 
+$\Gamma(z) = (z - 1)!$.
 
 %
 % 238

--- a/src/tex/wandw-ch12.tex
+++ b/src/tex/wandw-ch12.tex
@@ -247,27 +247,43 @@ $\Gamma(z) = (z - 1)!$.
 % 238
 %
 
-Example. Prove that
-
-[Consider the expression
-
-111 1
-
-z z z- ) 2(s + l)(2 + 2) z z + l)... z+m)
-
-in d
-
-It can be expressed in partial fractions in the form 2 -, where
-
-\ (-) / \ \ 1 1 ]\ (-)" f °° 1
-
-"=1 e "'( -)"!( =" 11
-
-Noting that 2 -,<-, itt-t, prove that 2 - .- \ 2 -;h- 0 as
-
-r=m-ri+\ r\ m-n + l)\ n=o n\ z + n [r=m-n+irl]
-
-m- <X) when z is not a negative integer.]
+%Example. 
+\begin{wandwexample*}
+  Prove that
+  \begin{displaymath}
+    \frac{1}{\Gamma(z+1)} + \frac{1}{\Gamma(z+2)} +
+    \frac{1}{\Gamma(z+3)} +  \ldots =
+    \frac{e}{\Gamma(z)} \thebrace{\frac{1}{z} - 
+      \frac{1}{1!} \, \frac{1}{z + 1} + 
+      \frac{1}{2!} \, \frac{1}{z + 2} 
+      - \ldots } .
+  \end{displaymath}
+  [Consider the expression
+  \begin{displaymath}
+    \frac{1}{z} + \frac{1}{z(z + 1)} + 
+    \frac{1}{z(z + 1)(z + 2)} + \ldots + 
+    \frac{1}{z(z + 1) \ldots (z + m)} .
+  \end{displaymath}
+  It can be expressed in partial fractions in the form 
+  $\displaystyle \sum_{n=0}^m \frac{a_n}{z + n}$, where
+  \begin{displaymath}
+    a_n = \frac{(-)^n}{n!} \thebrace{
+      1 + \frac{1}{1!} + \frac{1}{2!} + \ldots +
+      \frac{1}{(m - n)!}
+    } =
+    \frac{(-)^n}{n!} \thebrace{
+      e - \sum_{r = m - n + 1}^\infty \frac{1}{r!}
+    } .
+  \end{displaymath}
+  Noting that 
+  $\displaystyle \sum_{r = m - n + 1}^\infty \frac{1}{r!} 
+  < \frac{e}{(m-n+1)!}$, 
+  prove that $\displaystyle \sum_{n=0}^m \frac{(-)^n}{n!} \, 
+  \frac{1}{z+n}
+  \thebrace{\sum_{r = m - n + 1}^\infty \frac{1}{r!}} 
+  \rightarrow 0$ as
+  $m \rightarrow \infty$ when $z$ is not a negative integer.]
+\end{wandwexample*}
 
 \Subsection{12}{1}{3}{The evaluation of a general class of infinite products.}
 

--- a/src/tex/wandw-ch12.tex
+++ b/src/tex/wandw-ch12.tex
@@ -162,26 +162,61 @@ differential equation with rational coefficients.
 
 \Subsection{12}{1}{1}{Euler's formula for the Gamma-function.}
 
-By the definition of an
-infinite product we have
+By the definition of an infinite product we have
+\begin{align*}
+  \frac{1}{\Gamma(z)} 
+  &= z 
+    \thebracket{\lim_{m \rightarrow \infty} 
+    e^{\theparen{1 + \half + \ldots + \frac{1}{m} - \log m}z}
+    \vphantom{\prod_{n=1}^m}} % \vphantom is here to make the brackets
+                              % of the same size in both parts of the
+                              % formula  
+    \thebracket{\lim_{m \rightarrow \infty}
+    \prod_{n=1}^m
+    \thebrace{\theparen{1 + \frac{z}{n}}  e^{-\frac{z}{n}}}} \\
+  &=z \lim_{m \rightarrow \infty} \thebracket{
+    e^{\theparen{1 + \half + \ldots + \frac{1}{m} - \log m}z}
+    \prod_{n=1}^m
+    \thebrace{\theparen{1 + \frac{z}{n}}  e^{-\frac{z}{n}}}} \\
+  &= z \lim_{m \rightarrow \infty} \thebracket{
+    m^{-z} \prod_{n=1}^m \theparen{1 + \frac{z}{n}}} \\
+  &= z \lim_{m \rightarrow \infty} \thebracket{
+    \prod_{n=1}^{m-1} \theparen{1 + \frac{1}{n}}^{-z}
+    \prod_{n=1}^m \theparen{1 + \frac{z}{n}}} \\
+  &= z \lim_{m \rightarrow \infty} \thebracket{
+    \prod_{n=1}^{m} \thebrace{
+    \theparen{1 + \frac{z}{n}}
+    \theparen{1 + \frac{1}{n}}^{-z}
+    } \theparen{1 + \frac{1}{m}}^z} .
+\end{align*}
+Hence 
+\begin{displaymath}
+  \Gamma(z) = \frac{1}{z} \prod_{n=1}^{\infty} \thebrace{
+    \theparen{1 + \frac{1}{n}}^{z}
+    \theparen{1 + \frac{z}{n}}^{-1} }.
+\end{displaymath}
+This formula is due to Euler$^*$\footnote{It was given 
+in 1729 in a letter to Goldbacb, printed in Fuss'
+\emph{Corresp. Math.}}; % TODO footnote
+it is valid except when $z = 0, -1, -2, \ldots$. 
+\index{product for the Gamma-function}\index{Euler's product}
 
-TODO
+% Example. 
+\begin{wandwexample*}
+  Prove that
+  \begin{displaymath}
+    \Gamma(z) =
+    \lim_{n \rightarrow \infty} 
+    \frac{1 \cdot 2 \ldots % TODO if \cdot is a good choice here?
+      (n-1)}{z(z+1) \ldots(z+n-1)} n^z . 
+  \end{displaymath}
+  \addexamplecitation{Euler.}
+\end{wandwexample*}
 
-Hence T (.) = - H j(l + -j (l +,;j | .
+\Subsection{12}{1}{2}{The difference equation satisfied by the
+  Gamma-function.} 
 
-This formula is due to Euler*; it is valid except when = 0, - 1, - 2,
-....
-
-Example. Prove that
-
-,,,. 1.2...(n-l)
-
-r (2) = hm, .,. 7- - - . n\
-
-\addexamplecitation{Euler.}
-
-VlVl. The difference equation satisfied by the Gamma-function.
-
+\index{Difiference equation satisfied by the Gamma-function}
 We shall now shew that the function F (z) satisfies the difference
 equation
 
@@ -225,9 +260,6 @@ m-*---c ? =1
 This is one of the most important properties of the Gamma-function.
 Since F (1) = 1, it follows that, if 2: is a positive integer, F (2 )
 = (2 - 1) !.
-
-It was given in 1729 in a letter to Goldbacb, printed in Fuss'
-Corresp. Math.
 
 %
 % 238

--- a/src/tex/wandw-ch12.tex
+++ b/src/tex/wandw-ch12.tex
@@ -90,10 +90,11 @@ by the equation
   \frac{1}{\Gamma(z)} = ze^{\gamma z} \prod_{n=1}^\infty
   \thebrace{\theparen{1 + \frac{z}{n}}  e^{-\frac{z}{n}}} ;
 \end{displaymath}
-\index{Weierstrassian product} from this equation it is apparent that
-$\Gamma(z)$ \emph{is analytic except at the points
+\index{Weierstrassian product} from this equation \emph{it is apparent that
+$\Gamma(z)$ is analytic except at the points
   $z=0, -1, -2, \ldots$, where it has simple poles}.
 
+%\begin{smalltext} % TODO 
 Proofs have been published by
 H\"older$^\dagger$\footnote{\emph{Math. Ann.}  \textsc{XXVIII.}
   (1887), pp. 1-13.}, % TODO footnote/reference
@@ -104,6 +105,7 @@ and Barnes$^\S$\footnote{\emph{Messenger of Math.} \textsc{XXIX}. (1900),
 of a theorem known to Weierstrass \index{Weierstrass' theorem on
   Gamma-functions} that the Gamma-function does not satisfy any
 differential equation with rational coefficients.
+%\end{smalltext}  
 
 %Example 1.
 \begin{wandwexample}
@@ -112,7 +114,6 @@ differential equation with rational coefficients.
   \begin{displaymath}
     \Gamma(1) = 1, \qquad \Gamma'(1)=-\gamma,
   \end{displaymath}
-
   where $\gamma$ is Euler's constant.
 
   [Justify differentiating logarithmically the equation

--- a/src/tex/wandw.tex
+++ b/src/tex/wandw.tex
@@ -123,6 +123,7 @@
 
 \theoremstyle{remark}
 \newtheorem{wandwexample}{Example}
+\newtheorem*{wandwexample*}{Example}
 % \numberwithin{wandwexample}{subsubsection}
 
 %\newenvironment{wandwmiscexamples}{\miscexamples\begin{enumerate}}{\end{enumerate}}


### PR DESCRIPTION
Two subsections, 12.11 and 12.12, pages 237-238 are ready for a review.

Also, several subsections in Ch. 12, including 12.11 and 12.12 have only one 'Example' which stays unnumbered. I am suggesting a new environment, 'wandwexample*', to take care of this use case.
(This is just one-line definition.)
